### PR TITLE
Binary protocol over bluetooth

### DIFF
--- a/app/src/main/java/com/eveningoutpost/dexdrip/Models/DexdripPacket.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/Models/DexdripPacket.java
@@ -1,0 +1,8 @@
+package com.eveningoutpost.dexdrip.Models;
+
+/**
+ * Created by Radu Iliescu on 25.02.2015.
+ */
+public class DexdripPacket {
+    public static final int PACKET_DATA = 1;
+}

--- a/app/src/main/java/com/eveningoutpost/dexdrip/utils/PacketUtil.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/utils/PacketUtil.java
@@ -1,0 +1,52 @@
+package com.eveningoutpost.dexdrip.utils;
+
+import java.nio.ByteBuffer;
+import java.nio.IntBuffer;
+import java.nio.LongBuffer;
+import java.nio.ShortBuffer;
+
+/**
+ * Created by Radu Iliescu on 26.02.2015.
+ */
+public class PacketUtil {
+    public static int int32FromBuffer(byte data[], int offset) {
+        ByteBuffer bb = ByteBuffer.wrap(data, offset, 4);
+        IntBuffer sb = bb.asIntBuffer();
+        return sb.get();
+    }
+
+    public static int uint32FromBuffer(byte data[], int offset) {
+        int ret = int32FromBuffer(data, offset);
+
+        if (ret < 0) {
+            ret += 1 << 32;
+        }
+
+        return ret;
+    }
+
+    public static int int16FromBuffer(byte data[], int offset) {
+        ByteBuffer bb = ByteBuffer.wrap(data, offset, 2);
+        ShortBuffer sb = bb.asShortBuffer();
+        return sb.get();
+    }
+
+    public static int uint16FromBuffer(byte data[], int offset) {
+        int ret = int16FromBuffer(data, offset);
+
+        if (ret < 0) {
+            ret += 1 << 16;
+        }
+
+        return ret;
+    }
+
+    public static int uint8FromBuffer(byte data[], int offset) {
+        int ret = data[offset];
+
+        if (ret < 0) {
+            ret += 1 << 8;
+        }
+        return ret;
+    }
+}


### PR DESCRIPTION
Change data exachange over bluetooth to a binary format.

Advantages:
1. data can easily be decoded;
2. more robust to error and is not taking just parts of the packets;
3. can be easily extended:
- for example I want to add next getMs and a packet id to the packets; the bluetooth chip is buffering packets if here is no connection and packets can be get with read.