### PR TITLE
Marshmallow support for Bluetooth pairing

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -11,6 +11,7 @@
 
     <uses-permission android:name="android.permission.BLUETOOTH" />
     <uses-permission android:name="android.permission.BLUETOOTH_ADMIN" />
+    <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED" />

--- a/app/src/main/java/com/eveningoutpost/dexdrip/BluetoothScan.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/BluetoothScan.java
@@ -25,6 +25,7 @@ import com.activeandroid.query.Select;
 import com.eveningoutpost.dexdrip.Models.ActiveBluetoothDevice;
 import com.eveningoutpost.dexdrip.Services.DexCollectionService;
 import com.eveningoutpost.dexdrip.UtilityModels.CollectionServiceStarter;
+import com.eveningoutpost.dexdrip.utils.LocationHelper;
 
 import java.util.ArrayList;
 
@@ -75,6 +76,8 @@ public class BluetoothScan extends ListActivity implements NavigationDrawerFragm
                 }
             }
         }
+        // Will request that GPS be enabled for devices running Marshmallow or newer.
+        LocationHelper.requestLocationForBluetooth(this);
         mLeDeviceListAdapter = new LeDeviceListAdapter();
         setListAdapter(mLeDeviceListAdapter);
 

--- a/app/src/main/java/com/eveningoutpost/dexdrip/utils/LocationHelper.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/utils/LocationHelper.java
@@ -14,6 +14,10 @@ import com.eveningoutpost.dexdrip.R;
  * Helper for checking if location services are enabled on the device.
  */
 public class LocationHelper {
+    // Manually defining Marshmallow to maintain backwards API compatibility.
+    // http://developer.android.com/reference/android/os/Build.VERSION_CODES.html#M
+    private static final int MARSHMALLOW = 23;
+
     /**
      * Determine if GPS is currently enabled.
      *
@@ -60,8 +64,7 @@ public class LocationHelper {
      */
     public static void requestLocationForBluetooth(Activity activity) {
         // Location needs to be enabled for Bluetooth discovery on Marshmallow.
-        // To maintain compatibility with SDK 20, look for a version after lollipop.
-        if (Build.VERSION.SDK_INT > Build.VERSION_CODES.LOLLIPOP) {
+        if (Build.VERSION.SDK_INT >= MARSHMALLOW) {
             LocationHelper.requestLocation(activity);
         }
     }

--- a/app/src/main/java/com/eveningoutpost/dexdrip/utils/LocationHelper.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/utils/LocationHelper.java
@@ -1,0 +1,68 @@
+package com.eveningoutpost.dexdrip.utils;
+
+import android.app.Activity;
+import android.app.AlertDialog;
+import android.content.Context;
+import android.content.DialogInterface;
+import android.content.Intent;
+import android.location.LocationManager;
+import android.os.Build;
+
+import com.eveningoutpost.dexdrip.R;
+
+/**
+ * Helper for checking if location services are enabled on the device.
+ */
+public class LocationHelper {
+    /**
+     * Determine if GPS is currently enabled.
+     *
+     * On Android 6 (Marshmallow), location needs to be enabled for Bluetooth discovery to work.
+     *
+     * @param context The current app context.
+     * @return true if location is enabled, false otherwise.
+     */
+    public static boolean isLocationEnabled(Context context) {
+        LocationManager locationManager = (LocationManager) context.getSystemService(Context.LOCATION_SERVICE);
+        return locationManager.isProviderEnabled(LocationManager.GPS_PROVIDER);
+    }
+
+    /**
+     * Prompt the user to enable GPS location if it isn't already on.
+     *
+     * @param parent The currently visible activity.
+     */
+    public static void requestLocation(final Activity parent) {
+        if (LocationHelper.isLocationEnabled(parent)) {
+            return;
+        }
+
+        // Shamelessly borrowed from http://stackoverflow.com/a/10311877/868533
+
+        AlertDialog.Builder builder = new AlertDialog.Builder(parent);
+        builder.setTitle(R.string.gps_not_found_title);
+        builder.setMessage(R.string.gps_not_found_message);
+        builder.setPositiveButton(R.string.gps_yes, new DialogInterface.OnClickListener() {
+            public void onClick(DialogInterface dialogInterface, int i) {
+                parent.startActivity(new Intent(android.provider.Settings.ACTION_LOCATION_SOURCE_SETTINGS));
+            }
+        });
+        builder.setNegativeButton(R.string.gps_no, null);
+        builder.create().show();
+    }
+
+    /**
+     * Prompt the user to enable GPS location on devices that need it for Bluetooth discovery.
+     *
+     * Android 6 (Marshmallow) needs GPS enabled for Bluetooth discovery to work.
+     *
+     * @param activity The currently visible activity.
+     */
+    public static void requestLocationForBluetooth(Activity activity) {
+        // Location needs to be enabled for Bluetooth discovery on Marshmallow.
+        // To maintain compatibility with SDK 20, look for a version after lollipop.
+        if (Build.VERSION.SDK_INT > Build.VERSION_CODES.LOLLIPOP) {
+            LocationHelper.requestLocation(activity);
+        }
+    }
+}

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -84,6 +84,12 @@
     <string name="wifi_recievers_dialog_message">Comma separated list of ip:port (for example 37.142.132.220:50005,37.142.132.220:50010,mongodb://user:pass@ds053958.mongolab.com:53958/db/collection)</string>
     <string name="wifi_recievers_dialog_title">Enter ip addresses and ports of receivers (including mongodb addresses if needed)</string>
 
+    <!-- GPS Settings -->
+    <string name="gps_not_found_title">GPS Is Not Enabled</string>
+    <string name="gps_not_found_message">For Bluetooth discovery to work on newer devices, location must be enabled.</string>
+    <string name="gps_yes">Enable</string>
+    <string name="gps_no">No</string>
+
     <!-- broadcast settings -->
     <string name="pref_title_broadcast_enabled">Broadcast locally</string>
     <string name="pref_summary_broadcast_enabled">Enable local broadcast of data so other apps (eg. NightWatch) can listen on new values</string>


### PR DESCRIPTION
This PR adds pairing support for Bluetooth devices and Android phones running Marshmallow (fixes #121).

The fix required two changes. The first is the app has to request either fine-grain or coarse-grain location (I chose coarse grain just because). The other change is location services (GPS) needs to be enabled. On devices running Marshmallow only, a notification pops up telling them to enable GPS when they click "Scan for BT".

I tested this fix on my own Nexus 5 running Marshmallow and a different LG G3 running Lollipop (5.1.1).
![screenshot_20151125-115037](https://cloud.githubusercontent.com/assets/869213/11411691/863896a8-93a0-11e5-8ff7-60ae35083317.png)
